### PR TITLE
Fixed freshclam --daemon bug

### DIFF
--- a/common/optparser.c
+++ b/common/optparser.c
@@ -204,6 +204,7 @@ const struct clam_option __clam_options[] = {
     {NULL, "install-service", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD | OPT_FRESHCLAM, "", ""},
     {NULL, "uninstall-service", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD | OPT_FRESHCLAM, "", ""},
     {NULL, "daemon", 'd', CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD, "", ""},
+    {NULL, "service-mode", 0, CLOPT_TYPE_BOOL, MATCH_BOOL, 0, NULL, 0, OPT_CLAMD | OPT_FRESHCLAM, "", ""},
 #endif
 
     /* cmdline only - deprecated */

--- a/common/service.c
+++ b/common/service.c
@@ -90,9 +90,9 @@ int svc_install(const char *name, const char *dname, const char *desc)
     }
 
     if (strchr(modulepath, ' '))
-        snprintf(binpath, MAX_PATH - 1, "\"%s\" --daemon", modulepath);
+        snprintf(binpath, MAX_PATH - 1, "\"%s\" --daemon --service-mode", modulepath);
     else
-        snprintf(binpath, MAX_PATH - 1, "%s --daemon", modulepath);
+        snprintf(binpath, MAX_PATH - 1, "%s --daemon --service-mode", modulepath);
 
     svc = CreateServiceA(sm, name, dname, SERVICE_CHANGE_CONFIG,
                          SERVICE_WIN32_OWN_PROCESS,

--- a/freshclam/freshclam.c
+++ b/freshclam/freshclam.c
@@ -1905,9 +1905,11 @@ int main(int argc, char **argv)
 #endif
 
 #ifdef _WIN32
-        mprintf_disabled = 1;
-        svc_register("freshclam");
-        svc_ready();
+        if (optget(opts, "service-mode")->enabled) {
+            mprintf_disabled = 1;
+            svc_register("freshclam");
+            svc_ready();
+        }
 #endif
 
         /* Write PID of daemon process to pidfile. */


### PR DESCRIPTION
Services implementation interally uses --daemon, which would cause ordinary usage of --daemon to hang.
Added internal option --service-mode which resolves the problem.